### PR TITLE
Implemented shortlink input with '_' separator and multiple copy using ","

### DIFF
--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -85,7 +85,7 @@ export function copyShortlinkUrlToClipboard(shortlinkNames: string) {
         const text = allUrls.join("\n");
         copyToClipboard(text);
         showToast(Messages.copyToClipboard, Delays.done, "success");
-        //triggerAutoCloseWindowWithDelay();
+        triggerAutoCloseWindowWithDelay();
       }
     })
     .catch((error) => {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -24,7 +24,7 @@
 import React, { useEffect, useState } from "react"
 import { createRoot } from "react-dom/client"
 import { copyShortlinkUrlToClipboard } from "./clipboard"
-import { parseUserInputTextIntoCommand } from "./command"
+import {  CommandName,parseUserInputTextIntoCommand } from "./command"
 import {
   deleteShortlink,
   getAllShortlinks,
@@ -104,9 +104,16 @@ function handleOnChange(
   event: React.ChangeEvent<HTMLInputElement>,
   setUserInputText: React.Dispatch<React.SetStateAction<string>>
 ) {
-  const typedText = event.target.value
-  console.log("typedText:", typedText)
-  setUserInputText(typedText)
+  let typedText = event.target.value
+  if(typedText.includes(CommandName.CopyToClipboard)||typedText.includes(CommandName.CopyToClipboardShort)){
+    setUserInputText(typedText)
+  }
+  else{
+  typedText = typedText.replace(/[ ,]+$/, '');
+  let modifiedText = typedText.replace(/[ ,]+/g, "_");
+  console.log("typedText:", modifiedText)
+  setUserInputText(modifiedText)
+  }
 }
 
 async function handleEnterKey(event: React.KeyboardEvent<HTMLInputElement>, userInputText: string) {
@@ -114,7 +121,17 @@ async function handleEnterKey(event: React.KeyboardEvent<HTMLInputElement>, user
 
   console.log("typed: ", `'${userInputText}'`)
 
-  const command = parseUserInputTextIntoCommand(userInputText)
+function checkArg() {
+  if (/delete_/.test(userInputText)||/d_/.test(userInputText)) {
+    const modifieduserInputText = userInputText.replace("_"," ");
+    var result = parseUserInputTextIntoCommand(modifieduserInputText);
+    return result;
+  } else {
+      var result = parseUserInputTextIntoCommand(userInputText);
+      return result;
+    }
+  }
+var command = checkArg();
 
   switch (command.kind) {
     case "nothing": {


### PR DESCRIPTION
new shortlinks are added with removed spaces or commas and replace them with `_`
`Eg: foo, bar , `is saved as `foo_bar` (commas and spaces are replaced w/ underscores, then remove multiple underscores).

Extend the copy/c command such that you can pass in multiple arguments that are comma delimited. These should all be copied to the clipboard & joined w/ \n.
`Eg: copy foo_bar,baz`