### PR TITLE
feat: allow shortlink name to open new tab onclick.

### DIFF
--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -87,7 +87,9 @@ function Popup() {
             <div className="shortlink-container">
               {allShortlinks.map((shortlink) => (
                 <code key={shortlink.name} className="shortlink">
-                  {shortlink.name}
+                  <a href={`https://www.${shortlink.name}`} target="_blank" className="shortlink-link">
+                    {shortlink.name}
+                    </a>
                 </code>
               ))}
             </div>

--- a/src/style.css
+++ b/src/style.css
@@ -86,3 +86,8 @@ h1 {
   border: var(--default-border-style);
   padding: var(--default-padding);
 }
+
+.shortlink-link{
+  all: unset;
+  cursor: pointer;
+}


### PR DESCRIPTION
- clicking on a link will open the site corresponding to the link in a new tab.
- Remove the default styling of the link to maintain the original style. 
- Add hover effect to indicate the link.