### PR TITLE
Fix current shortlink URL list container spill over

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -88,6 +88,8 @@ body {
 
 /* Flex children. */
 #links {
+  display: flex;
+  flex-direction: column;
   flex-grow: 1;
   border-radius: var(--default-border-radius);
   border: var(--default-border-style);
@@ -176,7 +178,7 @@ h1 {
   transform: translateY(-100%);
 
   /* https://developer.mozilla.org/en-US/docs/Web/CSS/height */
-  height: 0;
+  height: auto;
 
   display: flex;
   color: #f1f5f9;
@@ -186,10 +188,9 @@ h1 {
 
 /* Set state when the div is shown */
 .current-url.show {
+  flex: 1;
   opacity: 1;
   transform: translateY(0px);
-
-  height: 2em;
 
   /* https://developer.mozilla.org/en-US/docs/Web/CSS/transition-delay */
   transition-delay:
@@ -199,10 +200,9 @@ h1 {
 
 /* Set state when the div is hidden */
 .current-url.hide {
+  flex: 0;
   opacity: 0;
   transform: translateY(-100%);
-
-  height: 0;
 
   /* https://developer.mozilla.org/en-US/docs/Web/CSS/transition-delay */
   transition-delay:


### PR DESCRIPTION
**Summary:**

- fixes the adaptive height behavior for the URLs container of the current short link
- adds missing `display: flex` property to `#link` elment

Follows the [flexbox technique](https://css-tricks.com/using-css-transitions-auto-dimensions/#aa-bonus-technique-flexbox) CSS transitions on elements with auto dimensions.

Fixes #33 

![image](https://github.com/r3bl-org/shortlink/assets/1707307/44278587-3a27-4a6d-9816-dd1089d1de83)
